### PR TITLE
Issue 88 - Correções no popup de suporte para sintaxe na função imprima() para pituguês

### DIFF
--- a/fontes/bibliotecas/dialetos/pitugues/funcoes-nativas.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/funcoes-nativas.ts
@@ -204,7 +204,7 @@ export const funcoesNativasPitugues: FuncaoNativaOuMetodoPrimitiva[] = [
             'Escreve um ou mais argumentos na saída padrão da aplicação.\n' +
             '## Interpolação \n' +
             'Delégua suporta interpolação de variáveis: \n\n' +
-            "```delegua\nvar comidaFavorita = 'strogonoff'\n" +
+            "```delegua\ncomidaFavorita = 'strogonoff'\n" +
             'escreva("Minha comida favorita é ${comidaFavorita}")\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'escreva(...argumentos)',
@@ -228,7 +228,7 @@ export const funcoesNativasPitugues: FuncaoNativaOuMetodoPrimitiva[] = [
             'Escreve um ou mais argumentos na saída padrão da aplicação.\n' +
             '## Interpolação \n' +
             'Delégua suporta interpolação de variáveis: \n\n' +
-            "```delegua\nvar comidaFavorita = 'strogonoff'\n" +
+            "```delegua\ncomidaFavorita = 'strogonoff'\n" +
             'imprima("Minha comida favorita é ${comidaFavorita}")\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'imprima(...argumentos)',

--- a/fontes/bibliotecas/dialetos/pitugues/funcoes-nativas.ts
+++ b/fontes/bibliotecas/dialetos/pitugues/funcoes-nativas.ts
@@ -203,8 +203,8 @@ export const funcoesNativasPitugues: FuncaoNativaOuMetodoPrimitiva[] = [
             '# `escreva()`\n' +
             'Escreve um ou mais argumentos na saída padrão da aplicação.\n' +
             '## Interpolação \n' +
-            'Delégua suporta interpolação de variáveis: \n\n' +
-            "```delegua\ncomidaFavorita = 'strogonoff'\n" +
+            'Pituguês suporta interpolação de variáveis: \n\n' +
+            "```pitugues\ncomidaFavorita = 'strogonoff'\n" +
             'escreva("Minha comida favorita é ${comidaFavorita}")\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'escreva(...argumentos)',
@@ -227,8 +227,8 @@ export const funcoesNativasPitugues: FuncaoNativaOuMetodoPrimitiva[] = [
             '# `imprima()`\n' +
             'Escreve um ou mais argumentos na saída padrão da aplicação.\n' +
             '## Interpolação \n' +
-            'Delégua suporta interpolação de variáveis: \n\n' +
-            "```delegua\ncomidaFavorita = 'strogonoff'\n" +
+            'Pituguês suporta interpolação de variáveis: \n\n' +
+            "```pitugues\ncomidaFavorita = 'strogonoff'\n" +
             'imprima("Minha comida favorita é ${comidaFavorita}")\n```' +
             '\n\n ### Formas de uso \n',
         exemploCodigo: 'imprima(...argumentos)',


### PR DESCRIPTION
Correção: removido a palavra 'var' no popup de suporte para sintaxe na função imprima() para pituguês.
Agora o popup de suporte de sintaxe aparece da função imprima() para o dialeto Pituguês não inclui mais a palavra "var" e faz referência ao nome correto do dialeto.

<img width="522" height="313" alt="image" src="https://github.com/user-attachments/assets/93c9eabf-3d65-4a82-acc9-f571c9f49cd3" />
