### PR TITLE
feat: atualiza destaques de sintaxe de funções nativas

### DIFF
--- a/gramaticas/pitugues.tmLanguage.json
+++ b/gramaticas/pitugues.tmLanguage.json
@@ -23,7 +23,7 @@
 	"functions": {
 		"patterns": [{
 			"name": "keyword.function.pitugues",
-			"match": "\\b(aleatorio|aleatorioEntre|escreva|imprima|inteiro|intervalo|leia|mapear|ordenar|real|tamanho|texto|importar|ajuda|exemplo|limpar|salvar|carregar|fun1|fun1R|ajuda|exemplo|limpar|salvar|carregar|fun1|fun1R|linspace|fun2|fun2R|rand|aprox|pale|vet|qtd|plot|max|min|intervalo|mediana|smtr|media|ve|sqr|variancia|devpad|covar|coefvar|coefcorr|coluna|linha|transposta|matriz|matrizmult|matrizinv|matrizid|deter|csl|sen|cos|tan|arcos|arsen|artan|exp|log|pot|aleat|raizq|vmed|deltas|deltat|acel|mrufh|mrufhp|mruvel|mruvfh|mruvfhp|mruvvel|mruvvelp|inercia|vmmv|van|periodo|pid)\\b"
+			"match": "\\b(aleatorio|aleatorioEntre|aleatorio_entre|algum|arredondar|combinar|contar|encontrar|encontrar_indice|encontrar_ultimo|encontrar_ultimo_indice|enumerar|escreva|filtrar_por|imprima|incluido|inteiro|intervalo|inverter|leia|mapear|maximo|minimo|ordenar|para_cada|primeiro_em_condicao|real|reduzir|somar|tamanho|texto|todos|todos_em_condicao|tupla|unico|vetor|importar|ajuda|exemplo|limpar|salvar|carregar|fun1|fun1R|ajuda|exemplo|limpar|salvar|carregar|fun1|fun1R|linspace|fun2|fun2R|rand|aprox|pale|vet|qtd|plot|max|min|mediana|smtr|media|ve|sqr|variancia|devpad|covar|coefvar|coefcorr|coluna|linha|transposta|matriz|matrizmult|matrizinv|matrizid|deter|csl|sen|cos|tan|arcos|arsen|artan|exp|log|pot|aleat|raizq|vmed|deltas|deltat|acel|mrufh|mrufhp|mruvel|mruvfh|mruvfhp|mruvvel|mruvvelp|inercia|vmmv|van|periodo|pid)\\b"
 		}]
 	},
 		"impossible": {


### PR DESCRIPTION
## O que foi alterado
Atualizada a lista de funções nativas no arquivo `pitugues.tmLanguage.json` dentro do grupo `"functions"` para incluir as novas funções suportadas pela linguagem (como `aleatorio_entre`, `para_cada`, `filtrar_por`, etc.).

## Motivo da mudança

As novas funções nativas do Pituguês estavam aparecendo como texto comum (sem destaque de cor/highlight colorido), o que deixava a leitura do código monótona no editor.

pitugues | delégua | python
<img width="1183" height="123" alt="Captura de tela 2026-07-16 180215" src="https://github.com/user-attachments/assets/4e27d21c-ac60-4b0c-b066-9e484208ba3b" />


## Observação

Notei que os métodos aplicados diretamente em tipos/objetos (como `numero.absoluto()` ou `texto.aparar()`) também estão sem destaque de cor. Lista completa de métodos de tipos:

```
# =========================
# primitivas-numero.ts
# =========================

numero = 3.75

numero.absoluto()

numero.arredondar()

numero.arredondar_para_baixo()

numero.arredondar_para_cima()

numero.formatar(2)

numero.raiz_quadrada()

numero.truncar()


# =========================
# primitivas-texto.ts
# =========================

texto = "  ola mundo  "

texto.aparar()

texto.aparar_fim()

texto.aparar_inicio()

"pitugues".capitalizar()

"pitugues".comeca_com("pi")

"ola".concatenar(" mundo")

"a,b,c".dividir(",")

# "banana".encontrar("na")

"banana".encontrar_ultimo("na")

"pitugues".fatiar(0, 3)

"{} {}".formatar("ola", "mundo")

"banana".inclui("na")

"Pitugues".maiusculo()

"Pitugues".minusculo()

"nome:sobrenome".particao(":")

"nome:sobrenome".partição(":")

"banana".substituir("na", "xx")

"banana".substituir_tudo("a", "o")

"abc".tamanho()

"arquivo.txt".termina_com(".txt")

"Pitugues".tudo_maiusculo()

"Pitugues".tudo_minusculo()


# =========================
# primitivas-vetor.ts
# =========================

v = [1, 2, 3]

v.adicionar(4)

v.clonar()

v.concatenar([5, 6])

v.estender([5, 6])

v.fatiar(1, 3)

v.indice(2)

v.inserir(1, 99)

v.juntar("-")

v.limpar()

v = [3, 1, 2]

v.ordenar()

v.remover(2)

v.remover_primeiro()

v.remover_todos(3)

v.remover_ultimo()

v.somar()

v.contem(1)

v.contém(1)


# =========================
# primitivas-dicionario.ts
# =========================

d = {"nome": "Ana", "idade": 20 }

d.chaves()

d.contem("nome")

d.contém("nome")

d.itens()

d.limpar()

d = {
    "nome": "Ana"
}

d.mesclar({
    "idade": 20
})

d.obter("nome")

d.popular({
    "cidade": "SP"
})

d.remover("cidade")

d.valores()


# =========================
# primitivas-tupla.ts
# =========================

t = tupla("a", "b", "c")

t.juntar("-")
```