### PR TITLE
Estende navegação de código para Pituguês: assinaturas no desktop e t…

### DIFF
--- a/fontes/assinaturas-metodos/delegua-provedor-assinaturas-metodos.ts
+++ b/fontes/assinaturas-metodos/delegua-provedor-assinaturas-metodos.ts
@@ -6,23 +6,74 @@ import primitivasDicionario from '@designliquido/delegua/bibliotecas/primitivas-
 import primitivasNumero from '@designliquido/delegua/bibliotecas/primitivas-numero';
 import primitivasTexto from '@designliquido/delegua/bibliotecas/primitivas-texto';
 import primitivasVetor from '@designliquido/delegua/bibliotecas/primitivas-vetor';
+import primitivasDicionarioPitugues from '@designliquido/delegua/bibliotecas/dialetos/pitugues/primitivas-dicionario';
+import primitivasNumeroPitugues from '@designliquido/delegua/bibliotecas/dialetos/pitugues/primitivas-numero';
+import primitivasTextoPitugues from '@designliquido/delegua/bibliotecas/dialetos/pitugues/primitivas-texto';
+import primitivasVetorPitugues from '@designliquido/delegua/bibliotecas/dialetos/pitugues/primitivas-vetor';
 import { formatarPrimitivas, funcoesNativasDelegua } from '../bibliotecas';
+import { funcoesNativasPitugues } from '../bibliotecas/dialetos/pitugues';
 import { FuncaoNativaOuMetodoPrimitiva } from '../bibliotecas/tipos';
 
 const primitivasDicionarioFormatadas = formatarPrimitivas(primitivasDicionario);
 const primitivasNumeroFormatadas = formatarPrimitivas(primitivasNumero);
 const primitivasTextoFormatadas = formatarPrimitivas(primitivasTexto);
 const primitivasVetorFormatadas = formatarPrimitivas(primitivasVetor);
+const ordenarPorNome = (a: FuncaoNativaOuMetodoPrimitiva, b: FuncaoNativaOuMetodoPrimitiva) => {
+    const nome1 = a.nome.toUpperCase();
+    const nome2 = b.nome.toUpperCase();
+    return nome1 > nome2 ? 1 : nome1 < nome2 ? -1 : 0;
+};
 const primitivas = [
     ...primitivasDicionarioFormatadas,
     ...primitivasNumeroFormatadas,
     ...primitivasTextoFormatadas,
     ...primitivasVetorFormatadas
-].sort((a, b) => {
-    const nome1 = a.nome.toUpperCase();
-    const nome2 = b.nome.toUpperCase();
-    return nome1 > nome2 ? 1 : nome1 < nome2 ? -1 : 0;
-});
+].sort(ordenarPorNome);
+const primitivasDicionarioPituguesFormatadas = formatarPrimitivas(primitivasDicionarioPitugues);
+const primitivasNumeroPituguesFormatadas = formatarPrimitivas(primitivasNumeroPitugues);
+const primitivasTextoPituguesFormatadas = formatarPrimitivas(primitivasTextoPitugues);
+const primitivasVetorPituguesFormatadas = formatarPrimitivas(primitivasVetorPitugues);
+const primitivasPitugues = [
+    ...primitivasDicionarioPituguesFormatadas,
+    ...primitivasNumeroPituguesFormatadas,
+    ...primitivasTextoPituguesFormatadas,
+    ...primitivasVetorPituguesFormatadas
+].sort(ordenarPorNome);
+
+/**
+ * Coleções de primitivas e funções nativas específicas de cada dialeto.
+ * O provedor seleciona o conjunto correto a partir do `languageId` do
+ * documento, para que Pituguês reconheça suas próprias primitivas e
+ * funções nativas (por exemplo, `escreva` em Delégua e `escrever` em
+ * Pituguês).
+ */
+interface ColecoesDialeto {
+    dicionario: FuncaoNativaOuMetodoPrimitiva[];
+    numero: FuncaoNativaOuMetodoPrimitiva[];
+    texto: FuncaoNativaOuMetodoPrimitiva[];
+    vetor: FuncaoNativaOuMetodoPrimitiva[];
+    todas: FuncaoNativaOuMetodoPrimitiva[];
+    funcoesNativas: FuncaoNativaOuMetodoPrimitiva[];
+}
+
+const colecoesDelegua: ColecoesDialeto = {
+    dicionario: primitivasDicionarioFormatadas,
+    numero: primitivasNumeroFormatadas,
+    texto: primitivasTextoFormatadas,
+    vetor: primitivasVetorFormatadas,
+    todas: primitivas,
+    funcoesNativas: funcoesNativasDelegua
+};
+
+const colecoesPitugues: ColecoesDialeto = {
+    dicionario: primitivasDicionarioPituguesFormatadas,
+    numero: primitivasNumeroPituguesFormatadas,
+    texto: primitivasTextoPituguesFormatadas,
+    vetor: primitivasVetorPituguesFormatadas,
+    todas: primitivasPitugues,
+    funcoesNativas: funcoesNativasPitugues
+};
+
 import { obterResultado } from '@designliquido/delegua-lsp/analise/cache-analise';
 
 /**
@@ -123,7 +174,8 @@ export class DeleguaProvedorAssinaturaMetodos implements vscode.SignatureHelpPro
         nomeObjeto: string,
         declaracoesPertinentes: { nome: string, tipo: string, declaracao: Declaracao }[],
         parametroAtivo?: number,
-        nomeMetodo?: string
+        nomeMetodo?: string,
+        colecoes: ColecoesDialeto = colecoesDelegua
     ): vscode.SignatureHelp | undefined {
         let tipoObjeto: string | undefined = undefined;
         const nomeProcurado = nomeMetodo ?? nomeObjeto;
@@ -137,7 +189,7 @@ export class DeleguaProvedorAssinaturaMetodos implements vscode.SignatureHelpPro
             switch (tipoObjeto) {
                 case 'dicionario':
                 case 'dicionário':
-                    const metodoDicionario = primitivasDicionarioFormatadas.find(m => m.nome === nomeProcurado);
+                    const metodoDicionario = colecoes.dicionario.find(m => m.nome === nomeProcurado);
                     if (metodoDicionario) {
                         return this.construirObjetoAssinatura(metodoDicionario, parametroAtivo);
                     }
@@ -145,21 +197,21 @@ export class DeleguaProvedorAssinaturaMetodos implements vscode.SignatureHelpPro
                     return undefined;
                 case 'numero':
                 case 'número':
-                    const metodoNumero = primitivasNumeroFormatadas.find(m => m.nome === nomeProcurado);
+                    const metodoNumero = colecoes.numero.find(m => m.nome === nomeProcurado);
                     if (metodoNumero) {
                         return this.construirObjetoAssinatura(metodoNumero, parametroAtivo);
                     }
 
                     return undefined;
                 case 'texto':
-                    const metodoTexto = primitivasTextoFormatadas.find(m => m.nome === nomeProcurado);
+                    const metodoTexto = colecoes.texto.find(m => m.nome === nomeProcurado);
                     if (metodoTexto) {
                         return this.construirObjetoAssinatura(metodoTexto, parametroAtivo);
                     }
 
                     return undefined;
                 case 'vetor':
-                    const metodoVetor = primitivasVetorFormatadas.find(m => m.nome === nomeProcurado);
+                    const metodoVetor = colecoes.vetor.find(m => m.nome === nomeProcurado);
                     if (metodoVetor) {
                         return this.construirObjetoAssinatura(metodoVetor, parametroAtivo);
                     }
@@ -167,7 +219,7 @@ export class DeleguaProvedorAssinaturaMetodos implements vscode.SignatureHelpPro
                     return undefined;
 
                 default:
-                    const metodoQualquer = primitivas.find(m => m.nome === nomeProcurado);
+                    const metodoQualquer = colecoes.todas.find(m => m.nome === nomeProcurado);
                     if (metodoQualquer) {
                         return this.construirObjetoAssinatura(metodoQualquer, parametroAtivo);
                     }
@@ -278,6 +330,10 @@ export class DeleguaProvedorAssinaturaMetodos implements vscode.SignatureHelpPro
         // Calcula qual parâmetro está ativo baseado na posição do cursor
         const parametroAtivo = this.calcularParametroAtivo(textoAntesCursor);
 
+        // Seleciona as primitivas e funções nativas do dialeto do documento.
+        const colecoes: ColecoesDialeto =
+            document.languageId === 'pitugues' ? colecoesPitugues : colecoesDelegua;
+
         const resultadoAnalise = obterResultado(document.uri.toString());
         const declaracoesPertinentes: { nome: string, tipo: string, declaracao: Declaracao }[] = 
             resultadoAnalise?.avaliadorSintatico.declaracoes.flatMap((declaracao): { nome: string, tipo: string, declaracao: Declaracao }[] => {
@@ -309,7 +365,8 @@ export class DeleguaProvedorAssinaturaMetodos implements vscode.SignatureHelpPro
                 resultadoObjeto[1],
                 declaracoesPertinentes,
                 parametroAtivo,
-                resultadoRegexFuncaoOuMetodo[1]
+                resultadoRegexFuncaoOuMetodo[1],
+                colecoes
             );
         }
 
@@ -341,7 +398,7 @@ export class DeleguaProvedorAssinaturaMetodos implements vscode.SignatureHelpPro
         }
 
         // Quarto caso: A `palavra` é uma função nativa global.
-        const possivelFuncaoNativa: FuncaoNativaOuMetodoPrimitiva | undefined = funcoesNativasDelegua.find(
+        const possivelFuncaoNativa: FuncaoNativaOuMetodoPrimitiva | undefined = colecoes.funcoesNativas.find(
             (funcaoNativa) => funcaoNativa.nome === resultadoRegexFuncaoOuMetodo[1]
         );
 

--- a/fontes/extensao-web.ts
+++ b/fontes/extensao-web.ts
@@ -219,7 +219,10 @@ export function activate(context: vscode.ExtensionContext) {
     // Ações de código
     context.subscriptions.push(
         vscode.languages.registerCodeActionsProvider(
-            { language: 'delegua', scheme: 'file' },
+            [
+                { language: 'delegua', scheme: 'file' },
+                { language: 'pitugues', scheme: 'file' }
+            ],
             new DeleguaProvedorAcoesCodigo(),
             { providedCodeActionKinds: DeleguaProvedorAcoesCodigo.tiposAcoesRapidas }
         )
@@ -340,7 +343,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Ir para definição
     context.subscriptions.push(
         vscode.languages.registerDefinitionProvider(
-            { language: 'delegua' },
+            [{ language: 'delegua' }, { language: 'pitugues' }],
             new DeleguaProvedorDefinicao()
         )
     );
@@ -348,7 +351,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Encontrar todas as referências
     context.subscriptions.push(
         vscode.languages.registerReferenceProvider(
-            { language: 'delegua' },
+            [{ language: 'delegua' }, { language: 'pitugues' }],
             new DeleguaProvedorReferencias()
         )
     );
@@ -356,7 +359,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Renomear símbolos
     context.subscriptions.push(
         vscode.languages.registerRenameProvider(
-            { language: 'delegua' },
+            [{ language: 'delegua' }, { language: 'pitugues' }],
             new DeleguaProvedorRenomeacao()
         )
     );
@@ -364,7 +367,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Assinaturas de métodos
     context.subscriptions.push(
         vscode.languages.registerSignatureHelpProvider(
-            { language: 'delegua' },
+            [{ language: 'delegua' }, { language: 'pitugues' }],
             new DeleguaProvedorAssinaturaMetodos()
         )
     );

--- a/fontes/extensao.ts
+++ b/fontes/extensao.ts
@@ -265,7 +265,10 @@ export function activate(context: vscode.ExtensionContext) {
     // Ações de código
     context.subscriptions.push(
         vscode.languages.registerCodeActionsProvider(
-            { language: 'delegua', scheme: 'file' },
+            [
+                { language: 'delegua', scheme: 'file' },
+                { language: 'pitugues', scheme: 'file' }
+            ],
             new DeleguaProvedorAcoesCodigo(),
             { providedCodeActionKinds: DeleguaProvedorAcoesCodigo.tiposAcoesRapidas }
         )
@@ -637,7 +640,9 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerDefinitionProvider(
             [
                 { scheme: 'file', language: 'delegua' },
-                { scheme: 'untitled', language: 'delegua' }
+                { scheme: 'untitled', language: 'delegua' },
+                { scheme: 'file', language: 'pitugues' },
+                { scheme: 'untitled', language: 'pitugues' }
             ],
             new DeleguaProvedorDefinicao()
         )
@@ -648,7 +653,9 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerReferenceProvider(
             [
                 { scheme: 'file', language: 'delegua' },
-                { scheme: 'untitled', language: 'delegua' }
+                { scheme: 'untitled', language: 'delegua' },
+                { scheme: 'file', language: 'pitugues' },
+                { scheme: 'untitled', language: 'pitugues' }
             ],
             new DeleguaProvedorReferencias()
         )
@@ -659,7 +666,9 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerRenameProvider(
             [
                 { scheme: 'file', language: 'delegua' },
-                { scheme: 'untitled', language: 'delegua' }
+                { scheme: 'untitled', language: 'delegua' },
+                { scheme: 'file', language: 'pitugues' },
+                { scheme: 'untitled', language: 'pitugues' }
             ],
             new DeleguaProvedorRenomeacao()
         )
@@ -705,7 +714,9 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerSignatureHelpProvider(
             [
                 { scheme: 'file', language: 'delegua' },
-                { scheme: 'untitled', language: 'delegua' }
+                { scheme: 'untitled', language: 'delegua' },
+                { scheme: 'file', language: 'pitugues' },
+                { scheme: 'untitled', language: 'pitugues' }
             ],
             new DeleguaProvedorAssinaturaMetodos()
         )

--- a/testes/assinaturas-metodos/delegua-provedor-assinaturas-metodos.test.ts
+++ b/testes/assinaturas-metodos/delegua-provedor-assinaturas-metodos.test.ts
@@ -442,6 +442,41 @@ describe('DeleguaProvedorAssinaturaMetodos', () => {
             expect(resultado.signatures.length).toBeGreaterThan(0);
         });
 
+        it('deve fornecer assinatura de função nativa exclusiva de Pituguês quando o documento é Pituguês', () => {
+            // 'aleatorio_entre' existe nas funções nativas de Pituguês (módulo real),
+            // não em Delégua (que usa 'aleatorioEntre').
+            mockDocument.languageId = 'pitugues';
+            mockDocument.uri.toString.mockReturnValue('file:///test/rota.pitu');
+            mockDocument.lineAt.mockReturnValue({ text: 'aleatorio_entre(' });
+            mockPosition.character = 16;
+
+            const resultado = provedor.provideSignatureHelp(
+                mockDocument,
+                mockPosition,
+                mockToken,
+                mockContext
+            );
+
+            expect(resultado).toBeDefined();
+            expect(resultado.signatures.length).toBeGreaterThan(0);
+        });
+
+        it('não deve reconhecer função nativa exclusiva de Pituguês num documento Delégua', () => {
+            // Sem languageId, o dialeto padrão é Delégua; 'aleatorio_entre' (com
+            // sublinhado) não existe nas nativas de Delégua mockadas.
+            mockDocument.lineAt.mockReturnValue({ text: 'aleatorio_entre(' });
+            mockPosition.character = 16;
+
+            const resultado = provedor.provideSignatureHelp(
+                mockDocument,
+                mockPosition,
+                mockToken,
+                mockContext
+            );
+
+            expect(resultado).toBeUndefined();
+        });
+
         it('deve fornecer assinatura para função definida no código', () => {
             const { FuncaoDeclaracao } = require('@designliquido/delegua/declaracoes');
             const { obterResultado } = require('@designliquido/delegua-lsp/analise/cache-analise');
@@ -577,7 +612,8 @@ describe('DeleguaProvedorAssinaturaMetodos', () => {
                 'meuTexto',
                 expect.any(Array),
                 expect.any(Number),
-                'tamanho'
+                'tamanho',
+                expect.any(Object)
             );
             expect(resultado).toBe(assinaturaEsperada);
         });

--- a/testes/extensao-web.test.ts
+++ b/testes/extensao-web.test.ts
@@ -158,7 +158,7 @@ describe('Extensão Web', () => {
         (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
     });
 
-    it('registra provedor de renomeação de símbolos Delégua', () => {
+    it('registra provedor de renomeação de símbolos para Delégua e Pituguês', () => {
         const context: any = {
             subscriptions: [],
             extensionUri: vscode.Uri.file('/test/path'),
@@ -167,7 +167,7 @@ describe('Extensão Web', () => {
         activate(context);
 
         expect(vscode.languages.registerRenameProvider).toHaveBeenCalledWith(
-            { language: 'delegua' },
+            [{ language: 'delegua' }, { language: 'pitugues' }],
             expect.anything()
         );
     });


### PR DESCRIPTION
# Navegação de código para Pituguês: assinaturas no desktop e todos os provedores na web

Fixes #100

## Problema

`registerSignatureHelpProvider` cobria apenas `delegua` e `delegua-testes`: quem escrevia Pituguês não tinha ajuda de assinatura de funções e métodos. E a extensão **web** estava defasada em relação ao desktop — nenhum dos cinco provedores de navegação (definição, referências, renomeação, ações de código, assinaturas) cobria `pitugues`, e vários sequer cobriam o esquema `untitled`.

Observação de contexto: a issue foi aberta contra a v0.27.5. Na `principal` atual, definição, referências, renomeação e ações de código **já** haviam sido estendidas para Pituguês no desktop. Este PR fecha o que restava.

## Solução

Pituguês passa a ter navegação de código completa nos dois ambientes:

**Desktop** (`fontes/extensao.ts`) — `signatureHelp` registrado também para `pitugues`, nos esquemas `file` e `untitled`.

**Web** (`fontes/extensao-web.ts`) — definição, referências, renomeação, ações de código e assinaturas estendidas para `pitugues`, alinhando a extensão web ao desktop.

## Correção acessória necessária (`DeleguaProvedorAssinaturaMetodos`)

Registrar o provedor para `pitugues` não bastaria. O provedor já **importava** as primitivas e as funções nativas de Pituguês, mas **nunca as usava**: os dois pontos de consulta — métodos de primitivas (`assinaturaParaChamadaMetodo`) e funções nativas globais (`provideSignatureHelp`) — só olhavam as coleções de Delégua. As importações estavam ali como intenção não finalizada.

Sem tratar isso, um documento `.pitu` não reconheceria as mais de 27 funções nativas exclusivas do dialeto (`aleatorio_entre`, `mapear`, `filtrar_por`, `para_cada`, `reduzir`, `ordenar` e outras). A correção agrupa primitivas e funções nativas em coleções por dialeto (`colecoesDelegua`, `colecoesPitugues`) e seleciona o conjunto pelo `document.languageId`. `assinaturaParaChamadaMetodo` passa a receber as coleções como parâmetro, com Delégua como padrão — preservando o comportamento existente.

## Testes

Dois casos novos em `testes/assinaturas-metodos/delegua-provedor-assinaturas-metodos.test.ts`, usando o módulo real de Pituguês (sem mock):

1. Documento Pituguês → reconhece `aleatorio_entre(` (nativa exclusiva do dialeto) e devolve assinatura;
2. Documento Delégua → **não** reconhece `aleatorio_entre(`, pois Delégua usa `aleatorioEntre` (camelCase). O par de nomes espelhados prova que a ramificação por `languageId` funciona.

Duas expectativas foram atualizadas para o comportamento novo: o registro de renomeação na web agora inclui Pituguês (`extensao-web.test.ts`), e a chamada de `assinaturaParaChamadaMetodo` recebe o novo parâmetro de coleções.

```
1.011 testes passando (1.009 originais + 2 novos)
tsc --noEmit: sem novos erros de tipo
```

## Observação de escopo (dois problemas pré-existentes)

Durante a validação, encontrei dois problemas **já presentes na `principal`**, reproduzidos com e sem este patch — portanto sem relação com esta mudança:

1. O script `typecheck` (`tsc --noEmit`) falha com 5 erros contra `@designliquido/delegua-lsp@0.0.3`, que não exporta `DocumentoLSP`, `AmbienteLSP` nem `EntradaDiretorio`. Passa despercebido porque a CI roda apenas os testes e o CodeQL, não o typecheck.
2. Ao rodar a suíte completa, `testes/avaliacao-sintatica` dispara um `TypeError` intermitente vindo de `@designliquido/delegua` (contaminação entre suítes). Isolada, ela passa (39/39). O mesmo ocorre na `principal` sem este patch.

Ambos merecem issues próprias; posso abri-las se for útil.

## Checklist

- [x] Pituguês com ajuda de assinatura no desktop, incluindo funções nativas do dialeto
- [x] Extensão web alinhada ao desktop (5 provedores estendidos para Pituguês)
- [x] Seleção de dialeto por `languageId`, não apenas registro de provedor
- [x] 2 testes de regressão novos comprovando a seleção de dialeto; 1.011 testes passando
- [x] Sem novas dependências; sem novos erros de tipo
