### PR TITLE
Adiciona auto-indentação e configuração completa ao Pituguês (#101)

### DIFF
--- a/configuracoes/configuracao-pitugues.json
+++ b/configuracoes/configuracao-pitugues.json
@@ -59,5 +59,27 @@
             "\\'",
             "\\'"
         ]
-    ]
+    ],
+    "indentationRules": {
+        "increaseIndentPattern": "^\\s*(se|senao\\s+se|senao|para|enquanto|fazer|funcao|classe|construtor|escolha|caso|tente|pegue|finalmente)\\b.*:\\s*(#.*)?$",
+        "decreaseIndentPattern": "^\\s*(senao\\s+se|senao|caso|pegue|finalmente)\\b.*:\\s*(#.*)?$"
+    },
+    "onEnterRules": [
+        {
+            "beforeText": {
+                "pattern": "^\\s*(se|senao\\s+se|senao|para|enquanto|fazer|funcao|classe|construtor|escolha|caso|tente|pegue|finalmente)\\b.*:\\s*(#.*)?$"
+            },
+            "action": {
+                "indent": "indent"
+            }
+        }
+    ],
+    "folding": {
+        "offSide": true,
+        "markers": {
+            "start": "^\\s*#\\s*#?region\\b",
+            "end": "^\\s*#\\s*#?endregion\\b"
+        }
+    },
+    "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)"
 }

--- a/testes/linguagens/configuracao-pitugues.test.ts
+++ b/testes/linguagens/configuracao-pitugues.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from '@jest/globals';
+import * as sistemaArquivos from 'fs';
+import caminho from 'path';
+
+/**
+ * Testes de regressão para o achado A2 (issue #101):
+ * Pituguês é uma linguagem indentada por dois-pontos e precisa de
+ * indentationRules, onEnterRules, folding e wordPattern, como o LMHT
+ * já possui. Estes testes validam os padrões contra código real, para
+ * que uma regressão no JSON de configuração seja detectada.
+ */
+describe('Configuração de linguagem Pituguês', () => {
+    const configuracao = JSON.parse(
+        sistemaArquivos.readFileSync(
+            caminho.join(__dirname, '../../configuracoes/configuracao-pitugues.json'),
+            'utf-8'
+        )
+    );
+
+    it('deve declarar as oito seções de configuração, como o LMHT', () => {
+        for (const secao of [
+            'comments',
+            'brackets',
+            'autoClosingPairs',
+            'surroundingPairs',
+            'indentationRules',
+            'onEnterRules',
+            'folding',
+            'wordPattern'
+        ]) {
+            expect(configuracao[secao]).toBeDefined();
+        }
+    });
+
+    describe('increaseIndentPattern', () => {
+        const regex = new RegExp(configuracao.indentationRules.increaseIndentPattern);
+
+        it.each([
+            'funcao rota(requisicao, resposta):',
+            '    se x > 0:',
+            'para cada i em intervalo(0, 5):',
+            'enquanto verdadeiro:',
+            'senao:',
+            'senao se y < 2:',
+            'escolha chave:',
+            '    caso 1:',
+            'tente:',
+            'pegue erro:',
+            'finalmente:',
+            'classe Pessoa(Animal):',
+            '    construtor(nome):',
+            'fazer:'
+        ])('aumenta indentação após "%s"', (linha) => {
+            expect(regex.test(linha)).toBe(true);
+        });
+
+        it.each([
+            'x = 10',
+            'escreva("texto: com dois pontos")',
+            'retorna x',
+            '# comentario: com dois pontos',
+            'y = {"chave": valor}'
+        ])('não aumenta indentação em "%s"', (linha) => {
+            expect(regex.test(linha)).toBe(false);
+        });
+    });
+
+    describe('decreaseIndentPattern', () => {
+        const regex = new RegExp(configuracao.indentationRules.decreaseIndentPattern);
+
+        it.each(['senao:', 'senao se y:', 'caso 2:', 'pegue e:', 'finalmente:'])(
+            'des-indenta a linha de continuação "%s"',
+            (linha) => {
+                expect(regex.test(linha)).toBe(true);
+            }
+        );
+
+        it.each(['se x:', 'funcao f():', 'x = 10'])(
+            'não des-indenta "%s"',
+            (linha) => {
+                expect(regex.test(linha)).toBe(false);
+            }
+        );
+    });
+
+    describe('onEnterRules', () => {
+        it('deve indentar a próxima linha após abertura de bloco', () => {
+            const regra = configuracao.onEnterRules[0];
+            const regex = new RegExp(regra.beforeText.pattern);
+            expect(regex.test('funcao rota(requisicao, resposta):')).toBe(true);
+            expect(regex.test('x = 10')).toBe(false);
+            expect(regra.action.indent).toBe('indent');
+        });
+    });
+
+    describe('folding', () => {
+        it('deve usar dobra por indentação (offSide)', () => {
+            expect(configuracao.folding.offSide).toBe(true);
+        });
+    });
+
+    describe('wordPattern', () => {
+        const regex = new RegExp(configuracao.wordPattern);
+
+        it.each(['numero', 'número', 'endereço', 'validação', 'usuário', 'variavel_conta'])(
+            'captura o identificador acentuado "%s" como uma palavra única',
+            (palavra) => {
+                const resultado = regex.exec(palavra);
+                expect(resultado).not.toBeNull();
+                expect(resultado![0]).toBe(palavra);
+            }
+        );
+    });
+});


### PR DESCRIPTION
# Auto-indentação e configuração completa de linguagem para Pituguês

Fixes #101

## Problema

Pituguês é uma linguagem indentada por dois-pontos, como Python, mas `configuracoes/configuracao-pitugues.json` declarava apenas `comments`, `brackets`, `autoClosingPairs` e `surroundingPairs`. Faltavam `indentationRules`, `onEnterRules`, `folding` e `wordPattern`.

Na prática, pressionar Enter após `funcao rota(requisicao, resposta):` **não** indentava a linha seguinte — indentação manual em cada bloco, o dia inteiro. É o atrito mais frequente possível. O padrão de qualidade já existia internamente (o LMHT tem as oito seções), mas não havia sido replicado para o Pituguês.

## Solução

As quatro seções que faltavam foram adicionadas, levando o Pituguês às mesmas oito do LMHT:

**`indentationRules`** — o `increaseIndentPattern` é ancorado às palavras-chave de bloco (`se`, `senao`, `senao se`, `para`, `enquanto`, `fazer`, `funcao`, `classe`, `construtor`, `escolha`, `caso`, `tente`, `pegue`, `finalmente`) terminadas em `:`. Ancorar às palavras-chave — em vez de um ingênuo "linha termina em dois-pontos" — evita indentar por dois-pontos que aparecem em **strings**, **comentários** e **dicionários literais**. O `decreaseIndentPattern` des-indenta as linhas de continuação (`senao`, `senao se`, `caso`, `pegue`, `finalmente`), para que fiquem alinhadas ao bloco a que pertencem.

**`onEnterRules`** — indenta a próxima linha após a abertura de um bloco.

**`folding`** — dobra por indentação (`offSide: true`), como em Python, com marcadores de região por comentário.

**`wordPattern`** — inclui letras acentuadas e sublinhado, para que identificadores como `validação` e `usuário` sejam tratados como uma palavra única (duplo-clique, expandir seleção). Sem isso, o duplo-clique quebraria a palavra no acento.

## Testes

Como não havia nenhum teste para as configurações de linguagem, este PR adiciona `testes/linguagens/configuracao-pitugues.test.ts` (36 casos):

1. Confirma que as oito seções estão presentes;
2. Valida o `increaseIndentPattern` contra código real — as 14 aberturas de bloco que **devem** indentar e, principalmente, os 5 casos que **não** devem (dois-pontos em string, em comentário, em dicionário literal, atribuição simples, `retorna`);
3. Valida o `decreaseIndentPattern` nas continuações;
4. Verifica o `onEnterRules` e o `folding.offSide`;
5. Verifica que o `wordPattern` captura identificadores acentuados inteiros (`número`, `endereço`, `validação`, `usuário`, `variavel_conta`).

```
testes/linguagens/configuracao-pitugues.test.ts: 36 testes passando
Suíte de produção completa: 970 testes passando (sem a suíte com falha pré-existente descrita abaixo)
```

## Observação de escopo (falha pré-existente não relacionada)

Ao rodar a suíte **completa**, a seção "estruturas mockadas" de `testes/completude/lmht-provedor-completude.test.ts` falha de forma **sensível à ordenação das suítes**: ela depende de um `jest.mock` que não sobrevive quando outra suíte reseta módulos no mesmo worker. Isso é reproduzível na `principal` sem este PR e não é causado por esta mudança:

- O novo teste passa isolado (36/36) e junto do teste de LMHT em qualquer ordem (46/46);
- Com apenas a configuração alterada e o novo teste **removido**, a suíte de produção passa 970/970;
- A presença de um arquivo de teste novo reordena a distribuição de suítes por worker, o que apenas **expõe** o vazamento pré-existente entre suítes de LMHT — não o introduz.

A correção adequada é adicionar `jest.resetModules()` ao `beforeEach` da suíte de LMHT, o que foge ao escopo desta issue. Posso abrir uma issue própria para isso.

## Checklist

- [x] Enter após abertura de bloco (`:`) passa a indentar automaticamente
- [x] Padrão ancorado às palavras-chave: não indenta por `:` em string, comentário ou dicionário
- [x] Continuações (`senao`, `caso`, `pegue`…) alinhadas corretamente
- [x] Dobra por indentação (offSide) e `wordPattern` com acentos
- [x] 36 testes de regressão novos (não havia testes de configuração de linguagem)
- [x] Mudança apenas em JSON e testes; nenhum código de runtime alterado
