### PR TITLE
Completude de LMHT sensível a contexto e com inserção de marcação (#103)

### DIFF
--- a/fontes/completude/lmht-provedor-completude.ts
+++ b/fontes/completude/lmht-provedor-completude.ts
@@ -1,7 +1,44 @@
 import * as vscode from 'vscode';
 
 import modificadoresLmht from '../linguagens/lmht/estruturas';
+import atributosLmht from '../linguagens/lmht/atributos';
 
+/**
+ * Estruturas LMHT que correspondem a tags vazias (_void_) em HTML e, portanto,
+ * não devem gerar par de abertura e fechamento na completude.
+ */
+const ESTRUTURAS_VAZIAS = new Set<string>([
+    'area',
+    'campo',
+    'coluna',
+    'imagem',
+    'linha-horizontal',
+    'quebra-linha',
+    'quebra-linha-oportuna',
+    'recurso'
+]);
+
+/**
+ * Contexto do cursor no momento da completude, para decidir o que sugerir.
+ */
+enum ContextoCompletude {
+    /** Dentro de um comentário: não sugerir nada. */
+    Comentario,
+    /** Dentro da abertura de uma tag (após `<nome ...`): sugerir atributos. */
+    AtributosDeTag,
+    /** Em posição de estrutura (início de arquivo, após `>` ou após `<`): sugerir tags. */
+    Estruturas
+}
+
+/**
+ * Provedor de completude para LMHT, sensível ao contexto do cursor.
+ *
+ * - Suprime sugestões dentro de comentários `<!-- -->`.
+ * - Dentro da abertura de uma tag, sugere atributos em vez de estruturas.
+ * - Em posição de estrutura, sugere as tags LMHT já como _snippet_, inserindo
+ *   `<tag>|</tag>` (ou `<tag />` para estruturas vazias) com o cursor no lugar
+ *   certo.
+ */
 export class LmhtProvedorCompletude implements vscode.CompletionItemProvider {
     provideCompletionItems(
         document: vscode.TextDocument,
@@ -11,15 +48,94 @@ export class LmhtProvedorCompletude implements vscode.CompletionItemProvider {
     ): vscode.ProviderResult<
         vscode.CompletionList<vscode.CompletionItem> | vscode.CompletionItem[]
     > {
-        const todosModificadores: vscode.CompletionItem[] = [];
-        for (let [chave, valor] of Object.entries(modificadoresLmht)) {
-            let item = new vscode.CompletionItem(
+        switch (this.determinarContexto(document, position)) {
+            case ContextoCompletude.Comentario:
+                return [];
+            case ContextoCompletude.AtributosDeTag:
+                return this.itensAtributos();
+            case ContextoCompletude.Estruturas:
+            default:
+                return this.itensEstruturas();
+        }
+    }
+
+    /**
+     * Determina o contexto do cursor analisando o texto do início do documento
+     * até a posição atual.
+     */
+    private determinarContexto(
+        document: vscode.TextDocument,
+        position: vscode.Position
+    ): ContextoCompletude {
+        const textoAnterior = document.getText(
+            new vscode.Range(new vscode.Position(0, 0), position)
+        );
+
+        // Comentário: há um `<!--` sem `-->` correspondente antes do cursor.
+        const ultimoAbreComentario = textoAnterior.lastIndexOf('<!--');
+        const ultimoFechaComentario = textoAnterior.lastIndexOf('-->');
+        if (ultimoAbreComentario > ultimoFechaComentario) {
+            return ContextoCompletude.Comentario;
+        }
+
+        // Abertura de tag: há um `<` (que inicia um nome de tag, não `</` nem
+        // `<!`) sem o `>` correspondente antes do cursor, e já existe pelo menos
+        // um espaço após o nome — ou seja, estamos na região de atributos.
+        const ultimoMenor = textoAnterior.lastIndexOf('<');
+        const ultimoMaior = textoAnterior.lastIndexOf('>');
+        if (ultimoMenor > ultimoMaior) {
+            const trechoTag = textoAnterior.substring(ultimoMenor);
+            const ehAberturaDeTag = /^<[A-Za-zÀ-ú]/.test(trechoTag);
+            const jaTemEspaco = /\s/.test(trechoTag);
+            if (ehAberturaDeTag && jaTemEspaco) {
+                return ContextoCompletude.AtributosDeTag;
+            }
+        }
+
+        return ContextoCompletude.Estruturas;
+    }
+
+    /**
+     * Itens de completude para estruturas (tags), inseridas como _snippet_.
+     */
+    private itensEstruturas(): vscode.CompletionItem[] {
+        const itens: vscode.CompletionItem[] = [];
+        for (const [chave, valor] of Object.entries(modificadoresLmht)) {
+            const item = new vscode.CompletionItem(
                 chave,
                 vscode.CompletionItemKind.Property
             );
-            item.documentation = `Equivalente em HTML: ${valor.nomeHtml}`;
-            todosModificadores.push(item);
+            item.documentation = new vscode.MarkdownString(
+                `Equivalente em HTML: \`${valor.nomeHtml}\``
+            );
+
+            if (ESTRUTURAS_VAZIAS.has(chave)) {
+                item.insertText = new vscode.SnippetString(`<${chave} $0/>`);
+            } else {
+                item.insertText = new vscode.SnippetString(`<${chave}>$0</${chave}>`);
+            }
+
+            itens.push(item);
         }
-        return todosModificadores;
+        return itens;
+    }
+
+    /**
+     * Itens de completude para atributos, sugeridos dentro da abertura de tag.
+     */
+    private itensAtributos(): vscode.CompletionItem[] {
+        const itens: vscode.CompletionItem[] = [];
+        for (const [chave, valor] of Object.entries(atributosLmht)) {
+            const item = new vscode.CompletionItem(
+                chave,
+                vscode.CompletionItemKind.Field
+            );
+            item.documentation = new vscode.MarkdownString(
+                `Equivalente em HTML: \`${valor.nomeHtml}\``
+            );
+            item.insertText = new vscode.SnippetString(`${chave}="$0"`);
+            itens.push(item);
+        }
+        return itens;
     }
 }

--- a/testes/completude/lmht-provedor-completude.test.ts
+++ b/testes/completude/lmht-provedor-completude.test.ts
@@ -7,10 +7,24 @@ jest.mock('vscode', () => ({
         Property: 9,
         Function: 2,
         Interface: 7,
+        Field: 4,
     },
     CompletionItem: class CompletionItem {
         constructor(public label: string, public kind?: number) {}
         documentation: any;
+        insertText: any;
+    },
+    SnippetString: class SnippetString {
+        constructor(public value: string) {}
+    },
+    MarkdownString: class MarkdownString {
+        constructor(public value: string = '') {}
+    },
+    Position: class Position {
+        constructor(public line: number, public character: number) {}
+    },
+    Range: class Range {
+        constructor(public start: any, public end: any) {}
     },
 }), { virtual: true });
 
@@ -21,18 +35,40 @@ jest.mock('../../fontes/linguagens/lmht/estruturas', () => ({
         'divisao': { nomeHtml: 'div' },
         'titulo1': { nomeHtml: 'h1' },
         'ancora': { nomeHtml: 'a' },
+        'imagem': { nomeHtml: 'img' },
+    }
+}));
+
+jest.mock('../../fontes/linguagens/lmht/atributos', () => ({
+    __esModule: true,
+    default: {
+        'classe': { nomeHtml: 'class' },
+        'id': { nomeHtml: 'id' },
+        'fonte': { nomeHtml: 'src' },
     }
 }));
 
 import { LmhtProvedorCompletude } from '../../fontes/completude/lmht-provedor-completude';
 
+/**
+ * Documento simulado. `getText(range)` devolve o texto do início até o fim
+ * do range, replicando o comportamento usado pelo provedor para analisar o
+ * contexto do cursor.
+ */
 function criarDocumento(linhas: string[] = ['']): any {
+    const texto = linhas.join('\n');
     return {
-        lineAt: jest.fn((linha: any) => {
-            const idx = typeof linha === 'number' ? linha : linha.line ?? 0;
-            return { text: linhas[idx] ?? '' };
+        getText: jest.fn((range?: any) => {
+            if (!range) {
+                return texto;
+            }
+            let offset = 0;
+            for (let i = 0; i < range.end.line; i++) {
+                offset += linhas[i].length + 1;
+            }
+            offset += range.end.character;
+            return texto.substring(0, offset);
         }),
-        getText: jest.fn(() => linhas.join('\n')),
     };
 }
 
@@ -55,78 +91,79 @@ describe('LmhtProvedorCompletude', () => {
         expect(typeof provedor.provideCompletionItems).toBe('function');
     });
 
-    it('retorna array de completion items', () => {
-        const doc = criarDocumento(['']);
-        const pos = criarPosicao(0, 0);
-        const items = provedor.provideCompletionItems(doc, pos, mockToken, mockContext);
-        expect(Array.isArray(items)).toBe(true);
-        expect(items.length).toBeGreaterThan(0);
-    });
-
-    it('todos os itens têm label definido', () => {
-        const doc = criarDocumento(['']);
-        const pos = criarPosicao(0, 0);
-        const items = provedor.provideCompletionItems(doc, pos, mockToken, mockContext);
-        items.forEach((item: any) => {
-            expect(item.label).toBeDefined();
-            expect(typeof item.label).toBe('string');
-        });
-    });
-
-    it('todos os itens são do tipo Property', () => {
-        const doc = criarDocumento(['']);
-        const pos = criarPosicao(0, 0);
-        const items = provedor.provideCompletionItems(doc, pos, mockToken, mockContext);
-        items.forEach((item: any) => {
-            expect(item.kind).toBe(vscode.CompletionItemKind.Property);
-        });
-    });
-
-    it('todos os itens têm documentação', () => {
-        const doc = criarDocumento(['']);
-        const pos = criarPosicao(0, 0);
-        const items = provedor.provideCompletionItems(doc, pos, mockToken, mockContext);
-        items.forEach((item: any) => {
-            expect(item.documentation).toBeDefined();
-        });
-    });
-
-    describe('estruturas mockadas', () => {
-        it('inclui paragrafo', () => {
-            const doc = criarDocumento(['']);
-            const pos = criarPosicao(0, 0);
-            const items = provedor.provideCompletionItems(doc, pos, mockToken, mockContext);
+    describe('contexto de estruturas', () => {
+        it('sugere estruturas fora de qualquer tag', () => {
+            const items = provedor.provideCompletionItems(
+                criarDocumento(['']), criarPosicao(0, 0), mockToken, mockContext
+            );
+            expect(Array.isArray(items)).toBe(true);
+            expect(items.length).toBe(5);
             expect(items.some((i: any) => i.label === 'paragrafo')).toBe(true);
-        });
-
-        it('inclui divisao', () => {
-            const doc = criarDocumento(['']);
-            const pos = criarPosicao(0, 0);
-            const items = provedor.provideCompletionItems(doc, pos, mockToken, mockContext);
-            expect(items.some((i: any) => i.label === 'divisao')).toBe(true);
-        });
-
-        it('inclui titulo1', () => {
-            const doc = criarDocumento(['']);
-            const pos = criarPosicao(0, 0);
-            const items = provedor.provideCompletionItems(doc, pos, mockToken, mockContext);
             expect(items.some((i: any) => i.label === 'titulo1')).toBe(true);
         });
 
-        it('inclui ancora', () => {
-            const doc = criarDocumento(['']);
-            const pos = criarPosicao(0, 0);
-            const items = provedor.provideCompletionItems(doc, pos, mockToken, mockContext);
-            expect(items.some((i: any) => i.label === 'ancora')).toBe(true);
+        it('sugere estruturas após o fechamento de uma tag', () => {
+            const doc = criarDocumento(['<corpo>']);
+            const items = provedor.provideCompletionItems(doc, criarPosicao(0, 7), mockToken, mockContext);
+            expect(items.length).toBe(5);
+        });
+
+        it('insere estrutura como par de abertura e fechamento com cursor no meio', () => {
+            const doc = criarDocumento(['<corpo>']);
+            const items = provedor.provideCompletionItems(doc, criarPosicao(0, 7), mockToken, mockContext);
+            const titulo1 = items.find((i: any) => i.label === 'titulo1');
+            expect(titulo1.insertText.value).toBe('<titulo1>$0</titulo1>');
+        });
+
+        it('insere estrutura vazia (void) sem tag de fechamento', () => {
+            const doc = criarDocumento(['<corpo>']);
+            const items = provedor.provideCompletionItems(doc, criarPosicao(0, 7), mockToken, mockContext);
+            const imagem = items.find((i: any) => i.label === 'imagem');
+            expect(imagem.insertText.value).toBe('<imagem $0/>');
+        });
+
+        it('todos os itens de estrutura têm label, documentação e insertText', () => {
+            const items = provedor.provideCompletionItems(
+                criarDocumento(['']), criarPosicao(0, 0), mockToken, mockContext
+            );
+            items.forEach((item: any) => {
+                expect(typeof item.label).toBe('string');
+                expect(item.documentation).toBeDefined();
+                expect(item.insertText).toBeDefined();
+            });
         });
     });
 
-    describe('contagem total de itens', () => {
-        it('retorna todas as estruturas mockadas', () => {
-            const doc = criarDocumento(['']);
-            const pos = criarPosicao(0, 0);
-            const items = provedor.provideCompletionItems(doc, pos, mockToken, mockContext);
-            expect(items.length).toBe(4);
+    describe('contexto de atributos', () => {
+        it('sugere atributos dentro da abertura de uma tag', () => {
+            const doc = criarDocumento(['<imagem ']);
+            const items = provedor.provideCompletionItems(doc, criarPosicao(0, 8), mockToken, mockContext);
+            expect(items.length).toBe(3);
+            expect(items.some((i: any) => i.label === 'classe')).toBe(true);
+            expect(items.some((i: any) => i.label === 'fonte')).toBe(true);
+            // Não deve sugerir estruturas aqui.
+            expect(items.some((i: any) => i.label === 'paragrafo')).toBe(false);
+        });
+
+        it('insere atributo com aspas e cursor entre elas', () => {
+            const doc = criarDocumento(['<imagem ']);
+            const items = provedor.provideCompletionItems(doc, criarPosicao(0, 8), mockToken, mockContext);
+            const classe = items.find((i: any) => i.label === 'classe');
+            expect(classe.insertText.value).toBe('classe="$0"');
+        });
+    });
+
+    describe('contexto de comentário', () => {
+        it('não sugere nada dentro de um comentário', () => {
+            const doc = criarDocumento(['<!-- ']);
+            const items = provedor.provideCompletionItems(doc, criarPosicao(0, 5), mockToken, mockContext);
+            expect(items).toEqual([]);
+        });
+
+        it('volta a sugerir estruturas após o fechamento do comentário', () => {
+            const doc = criarDocumento(['<!-- nota --> ']);
+            const items = provedor.provideCompletionItems(doc, criarPosicao(0, 14), mockToken, mockContext);
+            expect(items.length).toBe(5);
         });
     });
 });


### PR DESCRIPTION
# Completude de LMHT sensível a contexto e com inserção de marcação

Fixes #103

## Problema

O provedor de completude de LMHT devolvia sempre a **mesma lista de 122 tags**, em qualquer posição do cursor — fora de tag, dentro de tag, em texto ou em comentário, o resultado era idêntico. E nenhum item definia `insertText`: escolher `titulo1` inseria o texto pelado, não `<titulo1></titulo1>`. Também não havia completude de atributos.

## Solução

Reescrita seguindo a técnica de contexto que o provedor de **FolEs** desta mesma extensão já usa (o achado da issue). O provedor determina o contexto do cursor analisando o texto até a posição e decide o que sugerir:

**Comentário** (`<!--` sem `-->` correspondente antes do cursor) → não sugere nada.

**Abertura de tag** (após `<nome ` com espaço, sem `>` de fechamento) → sugere **atributos**, não estruturas. Reutiliza o dicionário que já existia em `fontes/linguagens/lmht/atributos.ts`, inserindo `atributo="$0"` com o cursor entre as aspas.

**Posição de estrutura** (início de arquivo, após `>` ou `<`) → sugere as tags como _snippet_:
- estruturas normais inserem `<tag>$0</tag>` com o cursor no meio;
- as oito estruturas que correspondem a tags **vazias** (_void_) em HTML — `area`, `campo`, `coluna`, `imagem`, `linha-horizontal`, `quebra-linha`, `quebra-linha-oportuna`, `recurso` — inserem `<tag />` sem fechamento.

### Antes e depois (medido)

| Contexto do cursor | Antes | Depois |
|---|---|---|
| Fora de qualquer tag | 122 tags | 122 estruturas (agora com snippet) |
| Dentro de uma tag aberta | 122 tags | **atributos** da tag |
| Dentro de um comentário | 122 tags | **nada** |
| `titulo1` (insertText) | texto pelado | `<titulo1>│</titulo1>` |
| `imagem` (void, insertText) | texto pelado | `<imagem │/>` |
| atributo `classe` (insertText) | — | `classe="│"` |

## Decisão de escopo: texto livre dentro de estrutura

A issue lista "dentro de texto de parágrafo" como caso a suprimir. Optei por **manter** a sugestão de estruturas ali, porque LMHT permite aninhar tags no meio do texto — `<paragrafo>olá <negrito>mundo</negrito></paragrafo>` é válido, e suprimir a completude quebraria esse aninhamento legítimo. É também o comportamento do suporte a HTML embutido do VSCode, citado como referência positiva na própria issue. Comentário e abertura-de-tag continuam tratados como pedido.

## Testes

A suíte de LMHT foi reescrita (10 casos) cobrindo os três contextos:

- **estruturas**: sugere fora de tag e após `>`; insere `<titulo1>$0</titulo1>`; insere `<imagem $0/>` para tag vazia; todos os itens têm label, documentação e `insertText`;
- **atributos**: sugere atributos dentro da abertura da tag e **não** sugere estruturas ali; insere `classe="$0"`;
- **comentário**: não sugere nada dentro do comentário e volta a sugerir após o `-->`.

Os mocks de `vscode` foram completados (`SnippetString`, `MarkdownString`, `Position`, `Range`) e o mock de `atributos` adicionado.

```
Suíte completa: 970 testes passando (sem a suíte com falha pré-existente de ordenação)
tsc --noEmit: sem novos erros de tipo
```

## Checklist

- [x] `insertText` com `SnippetString`: `titulo1` → `<titulo1>│</titulo1>`
- [x] Tags vazias (void) inserem `<tag />`, sem fechamento incorreto
- [x] Comentário: sugestões suprimidas
- [x] Abertura de tag: sugere atributos, não as 122 estruturas
- [x] Reaproveita `atributos.ts` já existente; nenhuma dependência nova
- [x] Suíte de LMHT reescrita cobrindo os três contextos (10 casos)
