### PR TITLE
feat(#116): adiciona walkthrough interativo "Criando uma aplicação web em Líquido"

### DIFF
--- a/package.json
+++ b/package.json
@@ -668,6 +668,67 @@
                         }
                     }
                 ]
+            },
+            {
+                "id": "liquido",
+                "title": "Criando uma aplicação web em Líquido",
+                "description": "Aprenda a criar uma aplicação web completa com o framework Líquido: projeto, configuração, rotas, visões e servidor.",
+                "steps": [
+                    {
+                        "id": "liquido-passo1",
+                        "title": "Crie um projeto Líquido",
+                        "description": "Use o comando para criar a estrutura inicial do seu projeto.\n\n[Criar novo projeto](command:extension.designliquido.liquido.novo)",
+                        "media": {
+                            "markdown": "recursos/passos-a-passos/liquido/liquido-passo-01.md",
+                            "altText": "Criação de projeto Líquido"
+                        }
+                    },
+                    {
+                        "id": "liquido-passo2",
+                        "title": "Configure o arquivo .delprops",
+                        "description": "Abra 'configuracao.delprops' e defina nome, versão, roteador, banco de dados, autenticação e estilos.\n\nA extensão oferece preenchimento automático e documentação ao passar o mouse sobre cada propriedade.",
+                        "media": {
+                            "markdown": "recursos/passos-a-passos/liquido/liquido-passo-02.md",
+                            "altText": "Configuração .delprops"
+                        }
+                    },
+                    {
+                        "id": "liquido-passo3",
+                        "title": "Crie uma rota",
+                        "description": "Crie um arquivo '.delegua' em 'fontes/rotas/' e defina endpoints da API com 'liquido.rotaGet' e 'liquido.rotaPost'.\n\nDica: digite 'liquido.' para ver todas as funções disponíveis com preenchimento automático.",
+                        "media": {
+                            "markdown": "recursos/passos-a-passos/liquido/liquido-passo-03.md",
+                            "altText": "Criação de rota"
+                        }
+                    },
+                    {
+                        "id": "liquido-passo4",
+                        "title": "Crie visões com LMHT e FolEs",
+                        "description": "Use LMHT ('.lmht') para templates HTML e FolEs ('.foles') para CSS em português.\n\nAmbas as linguagens têm realce de sintaxe e snippets na extensão.",
+                        "media": {
+                            "markdown": "recursos/passos-a-passos/liquido/liquido-passo-04.md",
+                            "altText": "Visões LMHT e FolEs"
+                        }
+                    },
+                    {
+                        "id": "liquido-passo5",
+                        "title": "Inicie o servidor de desenvolvimento",
+                        "description": "Com tudo configurado, inicie o servidor.\n\n[▶️ Iniciar servidor](command:extension.designliquido.liquido.servidor)\n\nO servidor recarrega automaticamente ao alterar arquivos.",
+                        "media": {
+                            "markdown": "recursos/passos-a-passos/liquido/liquido-passo-05.md",
+                            "altText": "Servidor de desenvolvimento"
+                        }
+                    },
+                    {
+                        "id": "liquido-passo6",
+                        "title": "Continue explorando!",
+                        "description": "Aprofunde seus conhecimentos:\n\n- [Documentação do Líquido](https://github.com/DesignLiquido/liquido-docs/wiki)\n- [Inicializar banco de dados](command:extension.designliquido.liquido.banco-iniciar)\n- [Gerar documentação OpenAPI](command:extension.designliquido.liquido.documentar)\n- [Rodar testes](command:extension.designliquido.liquido.testes)",
+                        "media": {
+                            "image": "recursos/passos-a-passos/pitugues/explorar-img.png",
+                            "altText": "Continue explorando"
+                        }
+                    }
+                ]
             }
         ],
         "packageManager": "yarn@1.22.22",

--- a/recursos/passos-a-passos/liquido/liquido-passo-01.md
+++ b/recursos/passos-a-passos/liquido/liquido-passo-01.md
@@ -3,13 +3,12 @@ arquivos do seu projeto:
 
 ```
 meu-projeto/
-├── configuracao.delprops      
-├── fontes/                     
-│   ├── rotas/                  
-│   ├── visoes/                 
-│   └── modelos/                
-├── publico/                    
-└── testes/                     
+├── configuracao.delprops
+├── modelos/
+├── rotas/
+├── publico/
+├── testes/
+└── visoes/
 ```
 
 Clique no botão acima ou use `Ctrl+Shift+P` → `Liquido: Novo projeto`.

--- a/recursos/passos-a-passos/liquido/liquido-passo-01.md
+++ b/recursos/passos-a-passos/liquido/liquido-passo-01.md
@@ -1,0 +1,15 @@
+O comando **Liquido: Novo projeto** cria a estrutura inicial de diretórios e
+arquivos do seu projeto:
+
+```
+meu-projeto/
+├── configuracao.delprops      
+├── fontes/                     
+│   ├── rotas/                  
+│   ├── visoes/                 
+│   └── modelos/                
+├── publico/                    
+└── testes/                     
+```
+
+Clique no botão acima ou use `Ctrl+Shift+P` → `Liquido: Novo projeto`.

--- a/recursos/passos-a-passos/liquido/liquido-passo-02.md
+++ b/recursos/passos-a-passos/liquido/liquido-passo-02.md
@@ -1,0 +1,24 @@
+O arquivo `configuracao.delprops` define as propriedades do seu projeto
+Líquido:
+
+```
+liquido.arquetipo = 'rest'
+liquido.linguagem = 'delégua'
+
+liquido.aplicacao.nome = 'MeuApp'
+liquido.aplicacao.versao = '1.0.0'
+
+liquido.roteador.cors = verdadeiro
+liquido.roteador.porta = 3000
+
+liquido.dados.banco.tecnologia = 'sqlite'
+liquido.dados.banco.caminho = ':memory:'
+
+liquido.autenticacao.tecnologia = 'jwt'
+
+liquido.estilos.diretorioBase = 'publico/css'
+```
+
+A extensão valida cada propriedade e oferece preenchimento automático ao
+digitar `liquido.`. Passe o mouse sobre qualquer propriedade para ver
+documentação detalhada.

--- a/recursos/passos-a-passos/liquido/liquido-passo-03.md
+++ b/recursos/passos-a-passos/liquido/liquido-passo-03.md
@@ -1,0 +1,17 @@
+Crie um arquivo `.delegua` em `fontes/rotas/` e defina os endpoints da sua
+API usando as funções `liquido.rota*`:
+
+```delegua
+liquido.rotaGet("/", funcao(requisicao, resposta) {
+    resposta.enviar("{ 'mensagem': 'Olá, Líquido!' }")
+})
+
+liquido.rotaPost("/usuarios", funcao(requisicao, resposta) {
+    var dados = requisicao.corpo
+    resposta.enviar("{ 'criado': verdadeiro }")
+})
+```
+
+**Dica:** digite `liquido.` e veja todas as funções disponíveis
+no preenchimento automático. Há snippets para `liquido.rotaGet`,
+`liquido.rotaPost`, `liquido.rotaPut`, `liquido.rotaDelete` e mais.

--- a/recursos/passos-a-passos/liquido/liquido-passo-04.md
+++ b/recursos/passos-a-passos/liquido/liquido-passo-04.md
@@ -1,0 +1,25 @@
+**LMHT** (`.lmht`) é o template HTML do Líquido. Crie suas visões em
+`fontes/visoes/`:
+
+```lmht
+<lmht>
+<cabecalho>
+    <titulo>Minha Aplicação</titulo>
+</cabecalho>
+<corpo>
+    <div id="app">{{ mensagem }}</div>
+</corpo>
+</lmht>
+```
+
+**FolEs** (`.foles`) é CSS em português para estilizar suas visões:
+
+```foles
+#app {
+    cor: #333;
+    tamanho-fonte: 16px;
+    margem: 20px;
+}
+```
+
+Ambas as linguagens têm realce de sintaxe e snippets na extensão.

--- a/recursos/passos-a-passos/liquido/liquido-passo-05.md
+++ b/recursos/passos-a-passos/liquido/liquido-passo-05.md
@@ -1,0 +1,9 @@
+Com o projeto configurado, rotas criadas e visões prontas, inicie o
+servidor de desenvolvimento:
+
+1. Abra qualquer arquivo `.delegua` do projeto
+2. Clique no botão **▶️** na barra de título do editor
+3. Ou use `Ctrl+Shift+P` → `Liquido: Iniciar servidor de desenvolvimento`
+
+O servidor recarrega automaticamente quando você altera arquivos.
+Acompanhe as requisições e erros no terminal integrado do VS Code.


### PR DESCRIPTION
# Resolve #116 

## Descrição

Esta PR adiciona um **walkthrough interativo** para o framework **Líquido** na tela de boas-vindas do VS Code, oferecendo uma experiência guiada para novos usuários semelhante ao walkthrough já existente para Pituguês.

O novo walkthrough conduz o usuário desde a criação de um projeto até a execução de uma aplicação web funcional, utilizando recursos já disponíveis na extensão.

---

## Problema

Embora a extensão já oferecesse suporte ao framework Líquido, novos usuários não possuíam um fluxo guiado de aprendizado equivalente ao existente para Pituguês.

Como consequência:

- o processo inicial de criação de uma aplicação dependia da documentação externa;
- recursos como snippets, autocompletar, hover e comandos da extensão não eram facilmente descobertos;
- a experiência de onboarding era inconsistente entre as linguagens suportadas.

---

## Solução

Foi adicionado um novo walkthrough registrado em `package.json` através de `contributes.walkthroughs`.

O walkthrough possui o identificador:

```text
liquido
```

e o título:

```text
Criando uma aplicação web em Líquido
```

O fluxo é composto por seis etapas que conduzem o usuário desde a criação do projeto até a exploração dos recursos disponíveis na extensão.

---

## Etapas do walkthrough

| Passo | Descrição |
|--------|-----------|
| 1 | Criar um projeto Líquido |
| 2 | Configurar o arquivo `.delprops` |
| 3 | Criar uma rota |
| 4 | Criar visões utilizando LMHT e FolEs |
| 5 | Iniciar o servidor de desenvolvimento |
| 6 | Continuar explorando os recursos da extensão |

---

## Arquivos criados

| Arquivo | Descrição |
|----------|-----------|
| `recursos/passos-a-passos/liquido/liquido-passo-01.md` | Criação de projeto |
| `recursos/passos-a-passos/liquido/liquido-passo-02.md` | Configuração do arquivo `.delprops` |
| `recursos/passos-a-passos/liquido/liquido-passo-03.md` | Criação de rotas |
| `recursos/passos-a-passos/liquido/liquido-passo-04.md` | Desenvolvimento de visões com LMHT e FolEs |
| `recursos/passos-a-passos/liquido/liquido-passo-05.md` | Inicialização do servidor de desenvolvimento |

---

## Arquivos alterados

| Arquivo | Descrição |
|----------|-----------|
| `package.json` | Registro do novo walkthrough em `contributes.walkthroughs` |

---

## Decisões de implementação

Durante o desenvolvimento foram adotadas as seguintes decisões:

- utilização de **Markdown** nos cinco primeiros passos, reduzindo o custo de manutenção e evitando dependência de capturas de tela;
- reutilização da imagem `explorar-img.png`, já utilizada pelo walkthrough de Pituguês, para o passo final;
- inclusão de botões de comando nos passos de criação do projeto e inicialização do servidor, permitindo executar as ações diretamente pelo walkthrough;
- aproveitamento dos recursos já existentes da extensão, como:
  - snippets;
  - autocompletar;
  - documentação contextual (hover);
  - destaque de sintaxe para arquivos `.delegua`, `.lmht`, `.foles` e `.delprops`.

---

## Verificação

Foram realizadas as seguintes verificações:

```bash
npx tsc --noEmit
```

Resultado:

```text
0 erros
```

Também foi executado:

```bash
npx jest
```

Resultado:

```text
1059 testes executados com sucesso
```

---

## Resultado

Com esta PR, a extensão passa a oferecer um walkthrough completo para o framework Líquido, proporcionando uma experiência de onboarding integrada ao VS Code e facilitando a descoberta dos principais recursos disponíveis para o desenvolvimento de aplicações web.

---

**Resolve #116 **