### PR TITLE
fix(#115): adiciona 17 comandos de tradução aos menus de contexto do editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -576,6 +576,91 @@
                     "when": "resourceLangId == delegua || resourceExtname == .delegua",
                     "command": "extension.designliquido.verFluxograma",
                     "group": "navigation"
+                },
+                {
+                    "when": "resourceLangId == css || resourceExtname == .css",
+                    "command": "extension.designliquido.traduzir.css.para.foles",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == foles || resourceExtname == .foles",
+                    "command": "extension.designliquido.traduzir.foles.para.css",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == html || resourceExtname == .html",
+                    "command": "extension.designliquido.traduzir.html.para.lmht",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == lmht || resourceExtname == .lmht",
+                    "command": "extension.designliquido.traduzir.lmht.para.html",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == sql || resourceExtname == .sql",
+                    "command": "extension.designliquido.traduzir.sql.para.lincones",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == lincones || resourceExtname == .lincones",
+                    "command": "extension.designliquido.traduzir.lincones.para.sql",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == javascript || resourceExtname == .js",
+                    "command": "extension.designliquido.traduzir.javascript.para.delegua",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == visualg || resourceExtname == .alg",
+                    "command": "extension.designliquido.traduzir.visualg.para.delegua",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.javascript",
+                    "group": "7_traducao/delegua@1"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.python",
+                    "group": "7_traducao/delegua@2"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.ruby",
+                    "group": "7_traducao/delegua@3"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.elixir",
+                    "group": "7_traducao/delegua@4"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.assemblyscript",
+                    "group": "7_traducao/delegua@5"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.x64.linux",
+                    "group": "7_traducao/delegua@6"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.x64.windows",
+                    "group": "7_traducao/delegua@7"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.arm.linux",
+                    "group": "7_traducao/delegua@8"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.arm.android",
+                    "group": "7_traducao/delegua@9"
                 }
             ],
             "editor/title/context": [
@@ -583,11 +668,251 @@
                     "when": "resourceLangId == delegua || resourceExtname == .delegua",
                     "command": "extension.designliquido.verFluxograma",
                     "group": "navigation"
+                },
+                {
+                    "when": "resourceLangId == css || resourceExtname == .css",
+                    "command": "extension.designliquido.traduzir.css.para.foles",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == foles || resourceExtname == .foles",
+                    "command": "extension.designliquido.traduzir.foles.para.css",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == html || resourceExtname == .html",
+                    "command": "extension.designliquido.traduzir.html.para.lmht",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == lmht || resourceExtname == .lmht",
+                    "command": "extension.designliquido.traduzir.lmht.para.html",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == sql || resourceExtname == .sql",
+                    "command": "extension.designliquido.traduzir.sql.para.lincones",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == lincones || resourceExtname == .lincones",
+                    "command": "extension.designliquido.traduzir.lincones.para.sql",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == javascript || resourceExtname == .js",
+                    "command": "extension.designliquido.traduzir.javascript.para.delegua",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == visualg || resourceExtname == .alg",
+                    "command": "extension.designliquido.traduzir.visualg.para.delegua",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.javascript",
+                    "group": "7_traducao/delegua@1"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.python",
+                    "group": "7_traducao/delegua@2"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.ruby",
+                    "group": "7_traducao/delegua@3"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.elixir",
+                    "group": "7_traducao/delegua@4"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.assemblyscript",
+                    "group": "7_traducao/delegua@5"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.x64.linux",
+                    "group": "7_traducao/delegua@6"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.x64.windows",
+                    "group": "7_traducao/delegua@7"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.arm.linux",
+                    "group": "7_traducao/delegua@8"
+                },
+                {
+                    "when": "resourceLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.arm.android",
+                    "group": "7_traducao/delegua@9"
+                }
+            ],
+            "editor/context": [
+                {
+                    "when": "editorLangId == css || resourceExtname == .css",
+                    "command": "extension.designliquido.traduzir.css.para.foles",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "editorLangId == foles || resourceExtname == .foles",
+                    "command": "extension.designliquido.traduzir.foles.para.css",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "editorLangId == html || resourceExtname == .html",
+                    "command": "extension.designliquido.traduzir.html.para.lmht",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "editorLangId == lmht || resourceExtname == .lmht",
+                    "command": "extension.designliquido.traduzir.lmht.para.html",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "editorLangId == sql || resourceExtname == .sql",
+                    "command": "extension.designliquido.traduzir.sql.para.lincones",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "editorLangId == lincones || resourceExtname == .lincones",
+                    "command": "extension.designliquido.traduzir.lincones.para.sql",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "editorLangId == javascript || resourceExtname == .js",
+                    "command": "extension.designliquido.traduzir.javascript.para.delegua",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "editorLangId == visualg || resourceExtname == .alg",
+                    "command": "extension.designliquido.traduzir.visualg.para.delegua",
+                    "group": "7_traducao"
+                },
+                {
+                    "when": "editorLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.javascript",
+                    "group": "7_traducao/delegua@1"
+                },
+                {
+                    "when": "editorLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.python",
+                    "group": "7_traducao/delegua@2"
+                },
+                {
+                    "when": "editorLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.ruby",
+                    "group": "7_traducao/delegua@3"
+                },
+                {
+                    "when": "editorLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.elixir",
+                    "group": "7_traducao/delegua@4"
+                },
+                {
+                    "when": "editorLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.assemblyscript",
+                    "group": "7_traducao/delegua@5"
+                },
+                {
+                    "when": "editorLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.x64.linux",
+                    "group": "7_traducao/delegua@6"
+                },
+                {
+                    "when": "editorLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.x64.windows",
+                    "group": "7_traducao/delegua@7"
+                },
+                {
+                    "when": "editorLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.arm.linux",
+                    "group": "7_traducao/delegua@8"
+                },
+                {
+                    "when": "editorLangId == delegua || resourceExtname == .delegua",
+                    "command": "extension.designliquido.traduzir.delegua.para.arm.android",
+                    "group": "7_traducao/delegua@9"
                 }
             ],
             "commandPalette": [
                 {
                     "command": "extension.designliquido.verFluxograma",
+                    "when": "editorLangId == delegua || resourceExtname == .delegua"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.css.para.foles",
+                    "when": "editorLangId == css || resourceExtname == .css"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.foles.para.css",
+                    "when": "editorLangId == foles || resourceExtname == .foles"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.html.para.lmht",
+                    "when": "editorLangId == html || resourceExtname == .html"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.lmht.para.html",
+                    "when": "editorLangId == lmht || resourceExtname == .lmht"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.sql.para.lincones",
+                    "when": "editorLangId == sql || resourceExtname == .sql"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.lincones.para.sql",
+                    "when": "editorLangId == lincones || resourceExtname == .lincones"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.javascript.para.delegua",
+                    "when": "editorLangId == javascript || resourceExtname == .js"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.visualg.para.delegua",
+                    "when": "editorLangId == visualg || resourceExtname == .alg"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.delegua.para.javascript",
+                    "when": "editorLangId == delegua || resourceExtname == .delegua"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.delegua.para.python",
+                    "when": "editorLangId == delegua || resourceExtname == .delegua"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.delegua.para.ruby",
+                    "when": "editorLangId == delegua || resourceExtname == .delegua"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.delegua.para.elixir",
+                    "when": "editorLangId == delegua || resourceExtname == .delegua"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.delegua.para.assemblyscript",
+                    "when": "editorLangId == delegua || resourceExtname == .delegua"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.delegua.para.x64.linux",
+                    "when": "editorLangId == delegua || resourceExtname == .delegua"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.delegua.para.x64.windows",
+                    "when": "editorLangId == delegua || resourceExtname == .delegua"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.delegua.para.arm.linux",
+                    "when": "editorLangId == delegua || resourceExtname == .delegua"
+                },
+                {
+                    "command": "extension.designliquido.traduzir.delegua.para.arm.android",
                     "when": "editorLangId == delegua || resourceExtname == .delegua"
                 }
             ],


### PR DESCRIPTION
# Resolve #115

## Descrição

Esta PR torna os comandos de tradução da extensão mais acessíveis, adicionando-os aos principais menus de contexto do VS Code e tornando sua exibição contextual conforme o tipo do arquivo aberto.

Além disso, os comandos passam a aparecer na **Command Palette** apenas quando forem aplicáveis ao documento atual, reduzindo ruído e melhorando a experiência de uso.

---

## Problema

A extensão disponibiliza **17 comandos de tradução** entre diferentes linguagens, porém todos estavam acessíveis apenas pela **Command Palette** (`Ctrl+Shift+P`).

Como consequência:

- os recursos de tradução eram pouco descobertos por novos usuários;
- não havia acesso rápido através do menu de contexto do editor ou do explorador;
- usuários que desconheciam previamente esses comandos dificilmente descobriam uma das principais funcionalidades da extensão.

---

## Solução

Os 17 comandos de tradução foram adicionados aos principais menus de contexto do VS Code, sendo exibidos apenas quando compatíveis com o arquivo atualmente selecionado.

Os comandos passam a estar disponíveis em:

- `editor/context` (menu de contexto do editor);
- `editor/title/context` (menu da aba do editor);
- `explorer/context` (menu de contexto do Explorador de Arquivos).

A visibilidade é controlada por `when` clauses, garantindo que apenas traduções relevantes sejam apresentadas para cada linguagem.

---

## Comportamento

Cada comando é exibido somente quando o arquivo ativo pertence a uma linguagem compatível.

Exemplos:

| Arquivo | Traduções disponíveis |
|----------|-----------------------|
| `.css` | FolEs |
| `.foles` | CSS |
| `.html` | LMHT |
| `.lmht` | HTML |
| `.sql` | LinConEs |
| `.lincones` | SQL |
| `.js` | Delégua (quando aplicável) |
| `.alg` (VisuAlg) | Traduções suportadas |
| `.delegua` | Tradução para os demais destinos suportados |

---

## Organização dos menus

Os comandos foram organizados para facilitar a navegação.

### Traduções bidirecionais

Os pares de tradução entre:

- CSS ↔ FolEs
- HTML ↔ LMHT
- SQL ↔ LinConEs

foram agrupados no submenu:

```text
7_traducao
```

### Traduções da Delégua

Os comandos de tradução a partir da Delégua foram agrupados em:

```text
7_traducao/delegua
```

incluindo separadores visuais para melhorar a organização do menu.

---

## Command Palette

Também foram adicionadas `when` clauses para todos os comandos de tradução na **Command Palette**.

Com isso, os comandos passam a aparecer apenas quando existe uma tradução válida para o arquivo atualmente aberto, reduzindo a quantidade de comandos irrelevantes exibidos.

---

## Arquivos alterados

| Arquivo | Descrição |
|----------|-----------|
| `package.json` | Adiciona os comandos de tradução aos menus de contexto e define suas condições de exibição |

---

## Verificação

Foram realizadas as seguintes verificações:

```bash
npx tsc --noEmit
```

Resultado:

```text
0 erros
```

Também foi executado:

```bash
npx jest
```

Resultado:

```text
1059 testes executados com sucesso
```

Além disso:

- `package.json` validado com sucesso;
- estrutura JSON permanece íntegra.

---

## Resultado

Com esta PR, os comandos de tradução tornam-se facilmente descobertos e acessíveis diretamente pelos menus de contexto do VS Code, proporcionando uma experiência mais intuitiva e reduzindo a dependência da Command Palette para acessar uma das principais funcionalidades da extensão.

---

**Resolve #115**